### PR TITLE
Fix #12 Custom active class not removed for previously selected menu …

### DIFF
--- a/src/scrollspy.js
+++ b/src/scrollspy.js
@@ -53,8 +53,8 @@ export class ScrollSpy {
   }
 
   removeCurrentActive({ ignore }) {
-    const { hrefAttribute, menuActiveTarget } = this.options
-    const items = `${menuActiveTarget}.active:not([${hrefAttribute}="${ignore.getAttribute(hrefAttribute)}"])`
+    const { hrefAttribute, menuActiveTarget, activeClass } = this.options
+    const items = `${menuActiveTarget}.${activeClass}:not([${hrefAttribute}="${ignore.getAttribute(hrefAttribute)}"])`
     const menuItems = this.menuList.querySelectorAll(items)
 
     menuItems.forEach((item) => item.classList.remove(this.options.activeClass))


### PR DESCRIPTION
The custom `activeClass` wasn't used when removing the active class for previously selected menu items.