### PR TITLE
doc: fix wrong argument description in the documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,8 +50,8 @@ You also replace `href` with the other name by `hrefAttribute` in `options`.
 | `offset`           | Number             | 0             | Offset number                      |
 | `hrefAttribute`    | String             | `href`        | The menu item's attribute name which contains section ID |
 | `activeClass`      | String             | `active`      | Active class name will be added into `menuActiveTarget`|
-| `scrollContainer`  | String|HTMLElement | empty string  | User Defined Scrolling Container |
-| `smoothScroll`  | Boolean|Object | `false`  | Enable the smooth scrolling feature |
+| `scrollContainer`  | String, HTMLElement | empty string  | User Defined Scrolling Container |
+| `smoothScroll`  | Boolean, Object | `false`  | Enable the smooth scrolling feature |
 | `smoothScrollBehavior`  | Function | `undefined`  | Define your smooth scroll behavior |
 
 ### ES6 example
@@ -83,10 +83,11 @@ scrollSpy('#main-menu', options)
       sectionClass: '.scrollspy',
       menuActiveTarget: '.menu-item',
       offset: 100,
+      // smooth scroll
       smoothScroll: true,
       smoothScrollBehavior: function(element) {
-        console.log('run smoothScrollBehavior', element)
-        element.scrollIntoView({ behavior: 'smooth' })
+        console.log('run "smoothScrollBehavior"...', element)
+        element.scrollIntoView({ behavior: 'smooth' }) // default behavior
       }
     })
   }


### PR DESCRIPTION
Fix wrong description for fields:
- `scrollContainer`
- `smoothScroll`

### Before
![image](https://user-images.githubusercontent.com/13513658/135903923-9022fede-cb04-42ec-af54-49b071b942d5.png)

### After
![image](https://user-images.githubusercontent.com/13513658/135904180-f043dea4-eda8-42fc-b2f2-52a72aa5c8d0.png)
